### PR TITLE
Create post task

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -1,19 +1,20 @@
 import schedule
 from flask import request, jsonify
-import json
+from validator import validate_pipeline, is_json, post_task_has_needed_data
+
+post_is_valid = validate_pipeline([is_json, post_task_has_needed_data])
+
 
 
 def post_task(request: request):
-  return_data = None
-
-  if not request.is_json:
-    return_data = jsonify({"error": "Invalid request data format. Expected JSON."}), 400
-  else:
-    json_data = jsonify({"test": ""}), 201
+  json_data = None
+  if post_is_valid(request):
+    json_data = jsonify({"message": "Task received successfully"}), 201
     print("1 -Hello, World!")
     job_that_executes_once()
+  else:
+    json_data = jsonify({"message": "Invalid request."}), 400
 
-  json_data = json.dumps(return_data)
   return json_data
 
 
@@ -24,4 +25,3 @@ def job_that_executes_once():
 
 def print_me(me: str):
   print(me)
-

--- a/request_handler.py
+++ b/request_handler.py
@@ -10,7 +10,6 @@ def post_task(request: request):
   json_data = None
   if post_is_valid(request):
     json_data = jsonify({"message": "Task received successfully"}), 201
-    print("1 -Hello, World!")
     job_that_executes_once()
   else:
     json_data = jsonify({"message": "Invalid request."}), 400

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,0 +1,16 @@
+import schedule
+
+
+def post_task():
+  print("1 -Hello, World!")
+  job_that_executes_once()
+  return 'Post task', 201
+
+
+def job_that_executes_once():
+    # Do some work that only needs to happen once...
+    schedule.every(5).seconds.do(print_me, me="me!!!")
+    return schedule.CancelJob
+
+def print_me(me: str):
+  print(me)

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,10 +1,20 @@
 import schedule
+from flask import request, jsonify
+import json
 
 
-def post_task():
-  print("1 -Hello, World!")
-  job_that_executes_once()
-  return 'Post task', 201
+def post_task(request: request):
+  return_data = None
+
+  if not request.is_json:
+    return_data = jsonify({"error": "Invalid request data format. Expected JSON."}), 400
+  else:
+    json_data = jsonify({"test": ""}), 201
+    print("1 -Hello, World!")
+    job_that_executes_once()
+
+  json_data = json.dumps(return_data)
+  return json_data
 
 
 def job_that_executes_once():
@@ -14,3 +24,4 @@ def job_that_executes_once():
 
 def print_me(me: str):
   print(me)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 schedule==1.2.0
 Flask==2.3.2
 pytest==7.4.0
+pytest-flask==1.2.0
+pytest-mock==3.11.1

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,4 +1,5 @@
 import pytest
+import schedule
 from app import app
 from views import TASK_ROUTE
 from request_handler import job_that_executes_once
@@ -28,13 +29,10 @@ def test_task_endpoint(client, mocker):
 
 def test_task_valid_post(client):
     """Test the '/task' route."""
-    # Prepare the JSON data to send with the request
     json_data = message_data_json_dummy()
 
-    # Make a POST request to the '/task' route
     response = client.post(TASK_ROUTE, json=json_data)
 
-    # Check the response status code and message
     assert response.status_code == 201
     assert response.json['message'] == "Task received successfully"
 
@@ -45,16 +43,10 @@ def test_task_route_missing_data(client):
     json_data = message_data_json_dummy()
     del json_data[missing_attribute]
 
-    # Make a POST request to the '/task' route
     response = client.post(TASK_ROUTE, json=json_data)
 
-    # Check the response status code and message
     assert response.status_code == 400
-    assert response.json['message'] == "The {missing_attribute} attribute is missing in the input to create a task."
-
-def test_task_route_accepts_post(client):
-    response = client.post(TASK_ROUTE)
-    assert response.status_code == 201
+    assert response.json.get('message') == "Invalid request."
 
 def test_hello_world():
     response = app.test_client().get('/')

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -11,20 +11,12 @@ def client():
         yield client
 
 def test_task_endpoint(client, mocker):
-    # Mock the behavior of schedule.every().seconds.do() to avoid scheduling the job
     mocker.patch('schedule.every')
 
-    # Call the job_that_executes_once directly to simulate the scheduler job
-    job_that_executes_once()
+    response = client.post(TASK_ROUTE, json=message_data_json_dummy())
 
-    # Send a POST request to '/task' with empty JSON data
-    response = client.post(TASK_ROUTE, json={})
-
-    # Assert the response status code and content
     assert response.status_code == 201
     assert response.get_json() == {"message": "Task received successfully"}
-
-    # Assert that job_that_executes_once() was called
     schedule.every.assert_called_once_with(5)
 
 def test_task_valid_post(client):

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,6 +1,26 @@
+import pytest
 from app import app
+from views import job_that_executes_once
 
-def test_hello_world():
-    response = app.test_client().get('/')
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_task_endpoint(client, mocker):
+    # Mock the behavior of schedule.every().seconds.do() to avoid scheduling the job
+    mocker.patch('schedule.every')
+
+    # Call the job_that_executes_once directly to simulate the scheduler job
+    job_that_executes_once()
+
+    # Send a POST request to '/task' with empty JSON data
+    response = client.post('/task', json={})
+
+    # Assert the response status code and content
     assert response.status_code == 200
-    assert response.data == b'Hello, World!'
+    assert response.get_json() == {"message": "Task received successfully"}
+
+    # Assert that job_that_executes_once() was called
+    schedule.every.assert_called_once_with(5)

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,6 +1,6 @@
 import pytest
 from app import app
-from views import job_that_executes_once
+from views import job_that_executes_once, TASK_ROUTE
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def test_task_endpoint(client, mocker):
     job_that_executes_once()
 
     # Send a POST request to '/task' with empty JSON data
-    response = client.post('/task', json={})
+    response = client.post(TASK_ROUTE, json={})
 
     # Assert the response status code and content
     assert response.status_code == 201
@@ -31,7 +31,7 @@ def test_task_valid_post(client):
     json_data = message_data_json_dummy()
 
     # Make a POST request to the '/task' route
-    response = client.post('/task', json=json_data)
+    response = client.post(TASK_ROUTE, json=json_data)
 
     # Check the response status code and message
     assert response.status_code == 201
@@ -45,14 +45,14 @@ def test_task_route_missing_data(client):
     del json_data[missing_attribute]
 
     # Make a POST request to the '/task' route
-    response = client.post('/task', json=json_data)
+    response = client.post(TASK_ROUTE, json=json_data)
 
     # Check the response status code and message
     assert response.status_code == 400
     assert response.json['message'] == "The {missing_attribute} attribute is missing in the input to create a task."
 
 def test_task_route_accepts_post(client):
-    response = client.post('/task')
+    response = client.post(TASK_ROUTE)
     assert response.status_code == 201
 
 def test_hello_world():
@@ -61,10 +61,14 @@ def test_hello_world():
     assert response.data == b'Hello, World!'
 
 
-def message_data_json_dummy() -> dict:
-    return {
+
+def message_data_json_dummy(**kwargs) -> dict:
+    dummy_data = {
         "user_id": "342342fsd",
         "group_ids": ["sdfds", "2131fsdf"],
         "message_data": "test data",
         "time_to_send": "yyyy-MM-dd"
     }
+    dummy_data.update(kwargs)
+
+    return dummy_data

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -19,8 +19,52 @@ def test_task_endpoint(client, mocker):
     response = client.post('/task', json={})
 
     # Assert the response status code and content
-    assert response.status_code == 200
+    assert response.status_code == 201
     assert response.get_json() == {"message": "Task received successfully"}
 
     # Assert that job_that_executes_once() was called
     schedule.every.assert_called_once_with(5)
+
+def test_task_valid_post(client):
+    """Test the '/task' route."""
+    # Prepare the JSON data to send with the request
+    json_data = message_data_json_dummy()
+
+    # Make a POST request to the '/task' route
+    response = client.post('/task', json=json_data)
+
+    # Check the response status code and message
+    assert response.status_code == 201
+    assert response.json['message'] == "Task received successfully"
+
+
+def test_task_route_missing_data(client):
+    """Test the '/task' route with missing data."""
+    missing_attribute = 'group_ids'
+    json_data = message_data_json_dummy()
+    del json_data[missing_attribute]
+
+    # Make a POST request to the '/task' route
+    response = client.post('/task', json=json_data)
+
+    # Check the response status code and message
+    assert response.status_code == 400
+    assert response.json['message'] == "The {missing_attribute} attribute is missing in the input to create a task."
+
+def test_task_route_accepts_post(client):
+    response = client.post('/task')
+    assert response.status_code == 201
+
+def test_hello_world():
+    response = app.test_client().get('/')
+    assert response.status_code == 200
+    assert response.data == b'Hello, World!'
+
+
+def message_data_json_dummy() -> dict:
+    return {
+        "user_id": "342342fsd",
+        "group_ids": ["sdfds", "2131fsdf"],
+        "message_data": "test data",
+        "time_to_send": "yyyy-MM-dd"
+    }

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,6 +1,7 @@
 import pytest
 from app import app
-from views import job_that_executes_once, TASK_ROUTE
+from views import TASK_ROUTE
+from request_handler import job_that_executes_once
 
 
 @pytest.fixture

--- a/validator.py
+++ b/validator.py
@@ -1,0 +1,28 @@
+from typing import Callable
+
+
+ValidatorFn = Callable[[int], bool]
+
+
+def validate_pipeline(validators: list[ValidatorFn]) -> ValidatorFn:
+    def validator(value: int) -> bool:
+        return all(validator(value) for validator in validators)
+
+    return validator
+
+def is_json(request) -> bool:
+    return request.is_json
+
+
+def post_task_has_needed_data(request) -> bool:
+    has_needed_data = True
+    if (
+      (request.json.get('user_id') is None) or
+      (request.json.get('group_ids') is None) or
+      (request.json.get('message_data') is None) or
+      (request.json.get('time_to_send') is None)
+      ):
+        has_needed_data = False
+
+    print(has_needed_data)
+    return has_needed_data

--- a/validator.py
+++ b/validator.py
@@ -24,5 +24,4 @@ def post_task_has_needed_data(request) -> bool:
       ):
         has_needed_data = False
 
-    print(has_needed_data)
     return has_needed_data

--- a/views.py
+++ b/views.py
@@ -1,6 +1,6 @@
-import schedule
 from flask import Blueprint
 from log.log_handler import log
+import request_handler
 
 TASK_ROUTE = '/task'
 
@@ -11,22 +11,10 @@ views_blueprint = Blueprint('views', __name__)
 @views_blueprint.route('/')
 @log
 def hello():
-    print("1 -Hello, World!")
-    job_that_executes_once()
-    print("2 - Hello, World!")
+    request_handler.job_that_executes_once()
     return 'Hello, World!'
 
 @views_blueprint.route(TASK_ROUTE, methods=['POST'])
 @log
 def task():
-    print("1 -Hello, World!")
-    job_that_executes_once()
-    return 'Post task', 201
-
-def job_that_executes_once():
-    # Do some work that only needs to happen once...
-    schedule.every(5).seconds.do(print_me, me="me!!!")
-    return schedule.CancelJob
-
-def print_me(me: str):
-  print(me)
+    return request_handler.post_task()

--- a/views.py
+++ b/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, request
 from log.log_handler import log
 import request_handler
 
@@ -17,4 +17,4 @@ def hello():
 @views_blueprint.route(TASK_ROUTE, methods=['POST'])
 @log
 def task():
-    return request_handler.post_task()
+    return request_handler.post_task(request)

--- a/views.py
+++ b/views.py
@@ -2,6 +2,8 @@ import schedule
 from flask import Blueprint
 from log.log_handler import log
 
+TASK_ROUTE = '/task'
+
 # Create a Blueprint object
 views_blueprint = Blueprint('views', __name__)
 
@@ -13,6 +15,13 @@ def hello():
     job_that_executes_once()
     print("2 - Hello, World!")
     return 'Hello, World!'
+
+@views_blueprint.route(TASK_ROUTE, methods=['POST'])
+@log
+def task():
+    print("1 -Hello, World!")
+    job_that_executes_once()
+    return 'Post task', 201
 
 def job_that_executes_once():
     # Do some work that only needs to happen once...


### PR DESCRIPTION
Problem: Server doesn't support Post task API
Solution: Added a '/task' route which excepts a post request + added validation that the request in valid
Impact: Views.py file
Testing plan: run pytest

Note: For this time, the server does not insert the task. This will be done in the next PR.  