### PR TITLE
Add coverage

### DIFF
--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Run Pytest
+    name: Run Pytest with Coverage
     runs-on: ubuntu-latest
 
     steps:
@@ -25,5 +25,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt  # Adjust this to match your requirements file, if applicable
 
-      - name: Run Pytest
-        run: python -m pytest
+      - name: Run Pytest with Coverage
+        run: |
+          coverage run -m pytest        # Run pytest with coverage
+
+      - name: Check Coverage
+        run: |
+          coverage report -m --fail-under=70

--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -32,3 +32,11 @@ jobs:
       - name: Check Coverage
         run: |
           coverage report -m --fail-under=70
+
+      - name: Check Pytest Pass
+        run: |
+          pytest_status=$?
+          if [ $pytest_status -ne 0 ]; then
+            echo "Pytest failed. Check the test logs for more details."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/__pycache__/test_routes.cpython-311-pytest-7.4.0.pyc
 __pycache__/
 test/__pycache__/
 /log/logs.log
+.coverage

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python app.py
 # Tests:
 ## Local (CLI):
 ```
-python -m pytest
+python -m pytest --cov --cov-report=term
 ```
 </br></br>
 # Related:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ apscheduler==3.10.1
 requests_mock==1.11.0
 response==0.5.0
 dataclasses-json==0.5.14
+coverage===7.2.7
+pytest-cov===4.1.0


### PR DESCRIPTION
Problem: When running tests & app, a coverage report didn't exist
Solution: Add the coverage package to the project and run report when running pytest & merging to branches in github
Impact: github actions
Testing plan: When going over PR, check coverage report + when running pytest, check coverage report